### PR TITLE
Allow collections through metadata alone

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ There are two ways to create collections:
 
   - **by pattern** - this is just passing a globing pattern that will group any files that match into the same collection.
   - **by metadata** - this is adding a specific `collection` metadata field to each item that you want to add to a collection.
-  
+
 The simplest way to create a collection is to use a pattern to match the files you want to group together:
 
 ```js
@@ -63,6 +63,7 @@ My article contents...
 ```
 
 All of the files with a matching `collection` will be added to an array that is exposed as a key of the same name on the global Metalsmith `metadata`.
+You can omit passing any options to the plugin when matching based on a `collection` property.
 
 ## CLI Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ function plugin(opts){
       debug('checking file: %s', file);
       var data = files[file];
       match(file, data).forEach(function(key){
-        if (key && ~~keys.indexOf(key)){
+        if (key && keys.indexOf(key) < 0){
           opts[key] = {};
           keys.push(key);
         }
@@ -165,7 +165,7 @@ function matcher(cols){
       collection.forEach(function(key){
         matches.push(key);
 
-        if (key && ~~keys.indexOf(key))
+        if (key && keys.indexOf(key) < 0)
           debug('adding new collection through metadata: %s', key);
       });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,11 @@ function plugin(opts){
       debug('checking file: %s', file);
       var data = files[file];
       match(file, data).forEach(function(key){
+        if (key && ~~keys.indexOf(key)){
+          opts[key] = {};
+          keys.push(key);
+        }
+
         metadata[key] = metadata[key] || [];
         metadata[key].push(data);
       });
@@ -158,7 +163,10 @@ function matcher(cols){
       var collection = data.collection;
       if (!Array.isArray(collection)) collection = [collection];
       collection.forEach(function(key){
-        if (key && ~keys.indexOf(key)) matches.push(key);
+        matches.push(key);
+
+        if (key && ~~keys.indexOf(key))
+          debug('adding new collection through metadata: %s', key);
       });
     }
     else {

--- a/test/fixtures/noconfig/src/four.md
+++ b/test/fixtures/noconfig/src/four.md
@@ -1,0 +1,3 @@
+---
+collection: books
+---

--- a/test/fixtures/noconfig/src/one.md
+++ b/test/fixtures/noconfig/src/one.md
@@ -1,0 +1,3 @@
+---
+collection: books
+---

--- a/test/fixtures/noconfig/src/three.md
+++ b/test/fixtures/noconfig/src/three.md
@@ -1,0 +1,3 @@
+---
+collection: movies
+---

--- a/test/fixtures/noconfig/src/two.md
+++ b/test/fixtures/noconfig/src/two.md
@@ -1,0 +1,1 @@
+Nothing

--- a/test/index.js
+++ b/test/index.js
@@ -211,4 +211,19 @@ describe('metalsmith-collections', function(){
       });
   });
 
+  it('should allow collections through metadata alone', function (done) {
+    var metalsmith = Metalsmith('test/fixtures/noconfig');
+    metalsmith
+      .use(collections({ movies: {} }))
+      .build(function(err){
+        if (err) return done(err);
+        var m = metalsmith.metadata();
+        assert.equal(2, m.books.length);
+        assert.equal(1, m.movies.length);
+        assert.equal(m.collections.books, m.books);
+        assert.equal(m.collections.movies, m.movies);
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
Currently each new collection has to be declared in the options. I'd like to see the plugin automatically register new collections it finds in the metadata, so I don't always have to change my build file.

This pull request does exactly this. It would also resolve issue [#11](https://github.com/segmentio/metalsmith-collections/issues/11).