### PR TITLE
Allow front matter and pattern collections.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -171,11 +171,10 @@ function matcher(cols){
           debug('adding new collection through metadata: %s', key);
       });
     }
-    else {
-      for (var key in matchers){
-        var m = matchers[key];
-        if (m && m.match(file)) matches.push(key);
-      }
+
+    for (var key in matchers){
+      var m = matchers[key];
+      if (m && m.match(file)) matches.push(key);
     }
 
     data.collection = unique(matches);

--- a/test/index.js
+++ b/test/index.js
@@ -243,4 +243,22 @@ describe('metalsmith-collections', function(){
       });
   });
 
+  it('should allow collections by pattern and front matter', function (done) {
+    var metalsmith = Metalsmith('test/fixtures/multi');
+    metalsmith
+      .use(collections({ articles: {}, posts: {}, drafts: {}, blog: '*.md' }))
+      .build(function(err){
+        if (err) return done(err);
+        var m = metalsmith.metadata();
+        assert.equal(3, m.blog.length);
+        assert.equal(2, m.articles.length);
+        assert.equal(1, m.drafts.length);
+        assert.equal(1, m.posts.length);
+        assert.equal(m.collections.blog, m.blog);
+        assert.equal(m.collections.articles, m.articles);
+        assert.equal(m.collections.drafts, m.drafts);
+        assert.equal(m.collections.posts, m.posts);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Adjust the matching code to allow collections to be defined in the front matter and by pattern.

Currently if you define collection in the front matter no patterns will match that file.

This aides in building something like a tagging system on a blog. All posts can be matched
with something like `'*.md'` or `'blog/**/*'` and then tags can be added in the individual
posts `collection` front matter.