### PR TITLE
Add file base property to collection file data.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ function plugin(opts){
     Object.keys(files).forEach(function(file){
       debug('checking file: %s', file);
       var data = files[file];
+      data.fileBase = file.split('/').pop().split('.').shift();
       match(file, data).forEach(function(key){
         if (key && keys.indexOf(key) < 0){
           opts[key] = {};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metalsmith-collections",
   "description": "A Metalsmith plugin that adds collections of files to the global metadata.",
   "repository": "git://github.com/segmentio/metalsmith-collections.git",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ describe('metalsmith-collections', function(){
         var m = metalsmith.metadata();
         assert.equal(2, m.articles.length);
         assert.equal(m.collections.articles, m.articles);
+        assert.equal('one', m.articles[0].fileBase)
         done();
       });
   });


### PR DESCRIPTION
Adds the ability to link to a specific blog post in your collection loop if you only want to display summaries in your loop.

Example use case in a Handlebars template:
```
{{#each collections.posts}}
  <div>
    <h2><a href="blog/{{this.fileBase}}/">{{{this.title}}}</a></h2>
    <p>{{this.summary}}</p>
  </div>
{{/each}}
```

The filename is not all that useful because in many cases the filename will reference a non-compiled file like `file.md` so I stripped extension and just provided the base of the filename.

Wasn't sure if I should edit `History.md` since that has dates and I'm not sure if/when this would get merged. Happy to edit that if you like.

Thanks for reviewing!