### PR TITLE
Clear collections (to prevent multiple additions when running via metalsmith-browser-sync)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,19 +29,20 @@ function plugin(opts){
     var metadata = metalsmith.metadata();
 
     /**
+     * Clear collections (to prevent multiple additions of the same file when running via metalsmith-browser-sync)
+     */
+
+    keys.forEach(function(key) {
+      metadata[key] = [];
+    });
+
+    /**
      * Find the files in each collection.
      */
 
     Object.keys(files).forEach(function(file){
       debug('checking file: %s', file);
       var data = files[file];
-      
-      /**
-       * Clean collections (to prevent multiple additions of the same file when serving via metalsmith-browser-sync)
-       */
-      match(file, data).forEach(function(key){
-        metadata[key] = [];
-      });
 
       match(file, data).forEach(function(key){
         if (key && keys.indexOf(key) < 0){

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,14 @@ function plugin(opts){
     Object.keys(files).forEach(function(file){
       debug('checking file: %s', file);
       var data = files[file];
+      
+      /**
+       * Clean collections (to prevent multiple additions of the same file when serving via metalsmith-browser-sync)
+       */
+      match(file, data).forEach(function(key){
+        metadata[key] = [];
+      });
+
       match(file, data).forEach(function(key){
         if (key && keys.indexOf(key) < 0){
           opts[key] = {};


### PR DESCRIPTION
When serving via metalsmith-browser-sync collections' metadata gets filled with duplications of the same files over time. E.g. having 2 files in collection - after 5 reloads there are 10 files. To prevent this multiple addition behavior let's clear all collections' metadata right at the beginning.