### PR TITLE
Added file name data to collection items

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,12 @@ My article contents...
 All of the files with a matching `collection` will be added to an array that is exposed as a key of the same name on the global Metalsmith `metadata`.
 You can omit passing any options to the plugin when matching based on a `collection` property.
 
+Adds a `path` property to the collection item's data which contains the file path of the generated file. For example, this can be used in mustache templates to create links:
+
+```html
+<h1><a href="/{{ path }}">{{ title }}</a></h1>
+```
+
 ### Collection Metadata
 
 Additional metadata can be added to the collection object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,9 @@ function plugin(opts){
     Object.keys(files).forEach(function(file){
       debug('checking file: %s', file);
       var data = files[file];
+
+      data.path = file
+
       match(file, data).forEach(function(key){
         if (key && keys.indexOf(key) < 0){
           opts[key] = {};

--- a/test/index.js
+++ b/test/index.js
@@ -301,4 +301,22 @@ describe('metalsmith-collections', function(){
         done();
       });
   });
+
+  it('should add file path', function(done){
+    var metalsmith = Metalsmith('test/fixtures/sort');
+    metalsmith
+      .use(collections({
+        articles: {
+          sortBy: 'title'
+        }
+      }))
+      .build(function(err){
+        if (err) return done(err);
+        var articles = metalsmith.metadata().articles;
+        assert(articles[0].path);
+        assert.equal(articles[0].path, 'one.md');
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
Adds a `file` property to the collection item's data which contains the file name of the generated file. For example, this can be used in templates to create links.

Includes test case.