### PR TITLE
Remove path metadata

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+1.0.0 / ????-??-??
+==================
+
+* Removed `path` from metadata. Instead use: metalsmith-path or metalsmith-paths
 
 0.7.0 / 2015-02-07
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -66,12 +66,6 @@ My article contents...
 All of the files with a matching `collection` will be added to an array that is exposed as a key of the same name on the global Metalsmith `metadata`.
 You can omit passing any options to the plugin when matching based on a `collection` property.
 
-Adds a `path` property to the collection item's data which contains the file path of the generated file. For example, this can be used in mustache templates to create links:
-
-```html
-<h1><a href="/{{ path }}">{{ title }}</a></h1>
-```
-
 ### Collection Metadata
 
 Additional metadata can be added to the collection object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,6 @@ function plugin(opts){
       debug('checking file: %s', file);
       var data = files[file];
 
-      data.path = file
-
       match(file, data).forEach(function(key){
         if (key && keys.indexOf(key) < 0){
           opts[key] = {};


### PR DESCRIPTION
Removed path metadata as this should be handled by another plugin.

Currently this conflicts with both [metalsmith-paths](https://www.npmjs.com/package/metalsmith-paths) and [metalsmith-path](https://www.npmjs.com/package/metalsmith-paths). It should be recommended to use one of these two plugins instead.
